### PR TITLE
Add noexcept to store code coverage -> 100%

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1308,7 +1308,7 @@
     },
     "@@bazel_tools//tools/test:extensions.bzl%remote_coverage_tools_extension": {
       "general": {
-        "bzlTransitiveDigest": "cizrA62cv8WUgb0cCmx5B6PRijtr/I4TAWxg/4caNGU=",
+        "bzlTransitiveDigest": "y48q5zUu2oMiYv7yUyi7rFB0wt14eqiF/RQcWT6vP7I=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {

--- a/src/pixelmatch/image_utils.cc
+++ b/src/pixelmatch/image_utils.cc
@@ -9,7 +9,7 @@
 
 namespace pixelmatch {
 
-std::optional<Image> readRgbaImageFromPngFile(const char* filename) {
+std::optional<Image> readRgbaImageFromPngFile(const char* filename) noexcept {
   int width, height, channels;
   auto data = stbi_load(filename, &width, &height, &channels, 4);
   if (!data) {
@@ -23,7 +23,7 @@ std::optional<Image> readRgbaImageFromPngFile(const char* filename) {
 }
 
 bool writeRgbaPixelsToPngFile(const char* filename, span<const uint8_t> rgbaPixels, int width,
-                              int height, size_t strideInPixels) {
+                              int height, size_t strideInPixels) noexcept {
   struct Context {
     std::ofstream output;
   };
@@ -37,7 +37,7 @@ bool writeRgbaPixelsToPngFile(const char* filename, span<const uint8_t> rgbaPixe
   }
 
   stbi_write_png_to_func(
-      [](void* context, void* data, int len) {
+      [](void* context, void* data, int len) noexcept {
         Context* contextObj = reinterpret_cast<Context*>(context);
         contextObj->output.write(static_cast<const char*>(data), len);
       },
@@ -47,7 +47,7 @@ bool writeRgbaPixelsToPngFile(const char* filename, span<const uint8_t> rgbaPixe
 }
 
 bool imageEquals(span<const uint8_t> img1, span<const uint8_t> img2, int width, int height,
-                 size_t strideInPixels) {
+                 size_t strideInPixels) noexcept {
   // Check for identical images, respecting stride.
   for (int y = 0; y < height; ++y) {
     const size_t rowStartIndex = y * strideInPixels;

--- a/src/pixelmatch/image_utils.h
+++ b/src/pixelmatch/image_utils.h
@@ -22,7 +22,7 @@ struct Image {
  * @param filename Filename to load.
  * @return std::optional<Image> containing the image, or std::nullopt if the file could not be read.
  */
-std::optional<Image> readRgbaImageFromPngFile(const char* filename);
+std::optional<Image> readRgbaImageFromPngFile(const char* filename) noexcept;
 
 /**
  * Save an image as a PNG file.
@@ -35,7 +35,7 @@ std::optional<Image> readRgbaImageFromPngFile(const char* filename);
  * @return true If the image was successfully saved.
  */
 bool writeRgbaPixelsToPngFile(const char* filename, span<const uint8_t> rgbaPixels, int width,
-                              int height, size_t strideInPixels);
+                              int height, size_t strideInPixels) noexcept;
 
 /**
  * Returns true if two images are bit-identical.
@@ -49,6 +49,6 @@ bool writeRgbaPixelsToPngFile(const char* filename, span<const uint8_t> rgbaPixe
  * @return true If the image is bit-identical.
  */
 bool imageEquals(span<const uint8_t> img1, span<const uint8_t> img2, int width, int height,
-                 size_t strideInPixels);
+                 size_t strideInPixels) noexcept;
 
 }  // namespace pixelmatch

--- a/src/pixelmatch/pixelmatch.cc
+++ b/src/pixelmatch/pixelmatch.cc
@@ -11,15 +11,15 @@ namespace {
 
 static constexpr size_t kPixelBytes = 4;
 
-inline float rgb2y(uint8_t r, uint8_t g, uint8_t b) {
+inline float rgb2y(uint8_t r, uint8_t g, uint8_t b) noexcept {
   return r * 0.29889531f + g * 0.58662247f + b * 0.11448223f;
 }
 
-inline float rgb2i(uint8_t r, uint8_t g, uint8_t b) {
+inline float rgb2i(uint8_t r, uint8_t g, uint8_t b) noexcept {
   return r * 0.59597799f - g * 0.27417610f - b * 0.32180189f;
 }
 
-inline float rgb2q(uint8_t r, uint8_t g, uint8_t b) {
+inline float rgb2q(uint8_t r, uint8_t g, uint8_t b) noexcept {
   return r * 0.21147017f - g * 0.52261711f + b * 0.31114694f;
 }
 
@@ -30,7 +30,7 @@ inline float rgb2q(uint8_t r, uint8_t g, uint8_t b) {
  * @param alpha The alpha value of the color, between 0 and 1.
  * @return The blended color.
  */
-inline uint8_t blend(uint8_t c, float a) {
+inline uint8_t blend(uint8_t c, float a) noexcept {
   return static_cast<uint8_t>(255.0f + (static_cast<float>(c) - 255.0f) * a);
 }
 
@@ -48,7 +48,7 @@ inline uint8_t blend(uint8_t c, float a) {
  *          or darkens (positive if img2 lightens). Returns 0 if the pixels are identical.
  */
 float colorDelta(span<const uint8_t> img1, span<const uint8_t> img2, size_t pos1, size_t pos2,
-                 bool yOnly) {
+                 bool yOnly) noexcept {
   uint8_t r1 = img1[pos1 + 0];
   uint8_t g1 = img1[pos1 + 1];
   uint8_t b1 = img1[pos1 + 2];
@@ -133,7 +133,7 @@ bool hasManySiblings(span<const uint8_t> img, int x1, int y1, int width, int hei
  * based on "Anti-aliased Pixel and Intensity Slope Detector" paper by V. Vysniauskas, 2009
  */
 bool antialiased(span<const uint8_t> img, int x1, int y1, int width, int height,
-                 size_t strideInPixels, span<const uint8_t> img2) {
+                 size_t strideInPixels, span<const uint8_t> img2) noexcept {
   const int x0 = std::max(x1 - 1, 0);
   const int y0 = std::max(y1 - 1, 0);
   const int x2 = std::min(x1 + 1, width - 1);
@@ -194,14 +194,14 @@ bool antialiased(span<const uint8_t> img, int x1, int y1, int width, int height,
           hasManySiblings(img2, maxX, maxY, width, height, strideInPixels));
 }
 
-inline void drawPixel(span<uint8_t> output, size_t pos, Color color) {
+inline void drawPixel(span<uint8_t> output, size_t pos, Color color) noexcept {
   output[pos + 0] = color.r;
   output[pos + 1] = color.g;
   output[pos + 2] = color.b;
   output[pos + 3] = color.a;
 }
 
-void drawGrayPixel(span<const uint8_t> img, size_t pos, float alpha, span<uint8_t> output) {
+void drawGrayPixel(span<const uint8_t> img, size_t pos, float alpha, span<uint8_t> output) noexcept {
   const uint8_t r = img[pos + 0];
   const uint8_t g = img[pos + 1];
   const uint8_t b = img[pos + 2];
@@ -212,7 +212,7 @@ void drawGrayPixel(span<const uint8_t> img, size_t pos, float alpha, span<uint8_
 }  // namespace
 
 int pixelmatch(span<const uint8_t> img1, span<const uint8_t> img2, span<uint8_t> output, int width,
-               int height, size_t strideInPixels, Options options) {
+               int height, size_t strideInPixels, Options options) noexcept {
   // In release builds, return -1 if a precondition fails since the asserts will not trigger.
   if (width <= 0 || height <= 0 || strideInPixels < static_cast<size_t>(width)) {
     assert(width > 0);

--- a/src/pixelmatch/pixelmatch.h
+++ b/src/pixelmatch/pixelmatch.h
@@ -18,10 +18,10 @@ using span = std::span<T>;
 template <typename T>
 class span {
 public:
-  constexpr span() = default;
-  ~span() = default;
+  constexpr span() noexcept = default;
+  ~span() noexcept = default;
 
-  constexpr span(T* data, size_t size) : data_(data), size_(size) {}
+  constexpr span(T* data, size_t size) noexcept : data_(data), size_(size) {}
 
   template <typename Container,
             std::enable_if_t<
@@ -30,17 +30,17 @@ public:
                         std::remove_pointer_t<decltype(std::declval<Container&>().data())> (*)[],
                         T (*)[]>::value,
                 int> = 0>
-  constexpr span(Container& container) : span(container.data(), container.size()) {}
+  constexpr span(Container& container) noexcept : span(container.data(), container.size()) {}
 
-  span(const span&) = default;
-  span& operator=(const span&) = default;
+  span(const span&) noexcept = default;
+  span& operator=(const span&) noexcept = default;
 
-  const T* data() const { return data_; }
-  size_t size() const { return size_; }
+  const T* data() const noexcept { return data_; }
+  size_t size() const noexcept { return size_; }
   bool empty() const { return size_ == 0; }
 
-  T operator[](size_t index) const { return data_[index]; }
-  T& operator[](size_t index) { return data_[index]; }
+  T operator[](size_t index) const noexcept { return data_[index]; }
+  T& operator[](size_t index) noexcept { return data_[index]; }
 
 private:
   T* data_ = nullptr;
@@ -92,6 +92,6 @@ struct Options {
  *         fails, returns -1.
  */
 int pixelmatch(span<const uint8_t> img1, span<const uint8_t> img2, span<uint8_t> output, int width,
-               int height, size_t strideInPixels, Options options = Options());
+               int height, size_t strideInPixels, Options options = Options()) noexcept;
 
 }  // namespace pixelmatch

--- a/tools/coverage.sh
+++ b/tools/coverage.sh
@@ -8,4 +8,5 @@ bazel coverage //...
 genhtml bazel-out/_coverage/_coverage_report.dat \
   --highlight \
   --legend \
+  --branch-coverage \
   --output-directory coverage-report


### PR DESCRIPTION
Exception handling code was being picked up by branch coverage, which I verified by disabling exceptions and rtti by adding the following to `.bazelrc`:

```sh
# Disable exceptions and rtti, they are not used.
build --cxxopt=-fno-exceptions --cxxopt=-fno-rtti
```

However, since pixelmatch may be used as a third party library I'd like to validate building with exceptions enabled as well.

Update the code to use `noexcept` so that we don't pay for the cost for exceptions even when exceptions are enabled.  Without the compiler-generated exception handling, code coverage goes back to 100%.