### PR TITLE
Update version number to 1.0.3, change how stb is integrated to be compatible with BCR

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@rules_cc//cc:defs.bzl", "cc_library")
 
+alias(
+    name = "pixelmatch",
+    actual = ":pixelmatch-cpp17",
+    visibility = ["//visibility:public"],
+)
+
 cc_library(
     name = "pixelmatch-cpp17",
     srcs = [

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -31,7 +31,7 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//:pixelmatch-cpp17",
-        "@stb//:image",
-        "@stb//:image_write",
+        "//third_party/stb:image",
+        "//third_party/stb:image_write",
     ],
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -3,17 +3,15 @@ A C++17 port of the JavaScript pixelmatch library, providing a small pixel-level
 
 To use, add the following to your MODULE.bazel file:
 ```
-bazel_dep(name = "pixelmatch-cpp17", version = "1.0.0")
-git_override(
-    module_name = "pixelmatch-cpp17",
-    remote = "https://github.com/jwmcglynn/pixematch-cpp17",
-)
+bazel_dep(name = "pixelmatch-cpp17", version = "1.0.3")
 ```
 """
 
-module(name = "pixelmatch-cpp17", repo_name = "pixelmatch-cpp17", version = "1.0.1")
-
-new_local_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:local.bzl", "new_local_repository")
+module(
+    name = "pixelmatch-cpp17",
+    version = "1.0.3",
+    compatibility_level = 0,
+)
 
 #
 # Build dependencies
@@ -23,13 +21,7 @@ bazel_dep(name = "rules_cc", version = "0.1.1")
 #
 # Test dependencies
 #
-bazel_dep(name = "googletest", repo_name = "com_google_gtest", version = "1.17.0", dev_dependency = True)
-
-new_local_repository(
-    name = "stb",
-    build_file = "//third_party:BUILD.stb",
-    path = "third_party/stb",
-)
+bazel_dep(name = "googletest", version = "1.16.0.bcr.1", dev_dependency = True)
 
 #
 # Fuzzing dependencies

--- a/README.md
+++ b/README.md
@@ -65,12 +65,7 @@ Compares two images, writes the output diff and returns the number of mismatched
 Add the following to your `MODULE.bazel` file:
 
 ```py
-bazel_dep(name = "pixelmatch-cpp17", version = "0.0.0")
-git_override(
-    module_name = "pixelmatch-cpp17",
-    remote = "https://github.com/jwmcglynn/pixelmatch-cpp17",
-    commit = "<latest commit hash>", # Ex: 2ab1b929916b97668698523a91e752413d01939c
-)
+bazel_dep(name = "pixelmatch-cpp17", version = "1.0.3")
 ```
 
 ### CMake

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -5,7 +5,7 @@ cc_library(
     name = "test_base",
     linkopts = ["-lm"],
     deps = [
-        "@com_google_gtest//:gtest_main",
+        "@googletest//:gtest_main",
     ],
 )
 

--- a/third_party/stb/BUILD.bazel
+++ b/third_party/stb/BUILD.bazel
@@ -157,5 +157,5 @@ cc_library(
     name = "vorbis",
     defines = ["STB_VORBIS_HEADER_ONLY"],
     visibility = ["//visibility:public"],
-    deps = ["//:vorbis-private"],
+    deps = [":vorbis-private"],
 )

--- a/third_party/stb/BUILD.bazel
+++ b/third_party/stb/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@pixelmatch-cpp17//third_party:stb.bzl", "stb_library")
+load("//third_party:stb.bzl", "stb_library")
 
 STB_COPTS = [
     "-Wno-unused-function",


### PR DESCRIPTION
In preparation for a BCR release of this project, change stb so it doesn't require new_local_repository.

Update the version number to 1.0.3 as well.